### PR TITLE
feat: add safe CLI helper with subcommand validation

### DIFF
--- a/ledgerize/CHANGELOG.md
+++ b/ledgerize/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+- Added safe CLI execution utilities with subcommand validation.
+- Introduced optional alias mapping and dry-run mode.
+- Documented troubleshooting steps and added tests for CLI safety.

--- a/ledgerize/README.md
+++ b/ledgerize/README.md
@@ -43,6 +43,18 @@ poetry run ledgerize report --db data/ledgerize.db \
 
 `rules.yml` and `accounts.yml` are YAML configuration files that control how transactions are categorized and which accounts they belong to. Consult the examples in the `samples/` directory to craft your own.
 
+## ⚙️ Exécution sûre des CLI
+
+Certaines versions locales peuvent manquer de sous-commandes. Pour éviter les erreurs du type `Error: No such command 'vault'`, l'application interroge désormais automatiquement les binaires avant de les exécuter.
+
+```bash
+❌ poetry run ledgerize vault init --label personal
+
+✅ poetry run python -m app main --dry-run ledgerize import --help
+```
+
+`--dry-run` valide la sous-commande et affiche la commande sans l'exécuter.
+
 ## 🔐 Vault security
 
 Ledgerize can encrypt banking data into `.lzvault` files so nothing sensitive remains on disk.
@@ -128,4 +140,12 @@ poetry run ruff src tests
 poetry run black --check src tests
 poetry run mypy src
 poetry run pytest
+```
+
+## 🛠️ Dépannage
+
+Afficher les sous-commandes reconnues par un binaire :
+
+```bash
+poetry run python -m app tools print-subcommands ledgerize
 ```

--- a/ledgerize/pyproject.toml
+++ b/ledgerize/pyproject.toml
@@ -5,7 +5,10 @@ description = "CLI tool to normalize and report multi-bank statements"
 authors = ["OpenAI <openai@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{ include = "ledgerize", from = "src" }]
+packages = [
+    { include = "ledgerize", from = "src" },
+    { include = "app", from = "src" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/ledgerize/src/app/__init__.py
+++ b/ledgerize/src/app/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for safe CLI execution."""

--- a/ledgerize/src/app/__main__.py
+++ b/ledgerize/src/app/__main__.py
@@ -1,0 +1,32 @@
+"""Entry point to dispatch submodules via ``python -m app``."""
+
+from __future__ import annotations
+
+import sys
+from typing import List
+
+from . import main as main_module
+from . import tools as tools_module
+
+
+def _usage() -> None:
+    print("Usage: python -m app <main|tools> ...", file=sys.stderr)
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        _usage()
+        sys.exit(1)
+    cmd, rest = args[0], args[1:]
+    if cmd == "main":
+        main_module.main(rest)
+    elif cmd == "tools":
+        tools_module.main(rest)
+    else:
+        _usage()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ledgerize/src/app/cli_aliases.py
+++ b/ledgerize/src/app/cli_aliases.py
@@ -1,0 +1,17 @@
+"""Optional mapping of deprecated subcommand aliases.
+
+This allows migration of old CLI usages to the current canonical commands.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Map of binary -> {alias: canonical}
+ALIASES: Dict[str, Dict[str, str]] = {
+    # Example: historically ``ledgerize sync`` became ``ledgerize import``
+    "ledgerize": {
+        "sync": "import",
+        "analyse": "report",
+    }
+}

--- a/ledgerize/src/app/cli_safe.py
+++ b/ledgerize/src/app/cli_safe.py
@@ -1,0 +1,186 @@
+"""Safely execute external CLI commands with subcommand validation."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from subprocess import CompletedProcess
+from typing import Iterable, Sequence, Set
+
+from .cli_aliases import ALIASES
+
+logger = logging.getLogger(__name__)
+
+
+def _run_help(binary: str) -> str:
+    """Return the combined stdout/stderr of ``binary --help``."""
+    try:
+        cp = subprocess.run(
+            [binary, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - handled by caller
+        raise RuntimeError(f"Command not found: {binary}") from exc
+    return (cp.stdout or "") + "\n" + (cp.stderr or "")
+
+
+def _iter_command_blocks(text: str) -> Iterable[Sequence[str]]:
+    """Yield blocks of indented lines that likely contain subcommands."""
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        lower = line.lower()
+        if "command" in lower and line.strip().endswith(":"):
+            # classic "Commands:"/"Subcommands:" block
+            start = idx + 1
+        elif (
+            line.strip().endswith(":")
+            and "option" not in lower
+            and idx + 1 < len(lines)
+        ):
+            # heuristic: any colon line (except options) followed by indented lines
+            start = idx + 1
+        else:
+            continue
+
+        block: list[str] = []
+        for line_ in lines[start:]:
+            if not line_.strip():
+                if block:
+                    break
+                continue
+            if re.match(r"^\s{2,}\S", line_):
+                block.append(line_)
+            elif block:
+                break
+        if block:
+            yield block
+
+
+def list_subcommands(binary: str) -> Set[str]:
+    """Return the set of available subcommands for ``binary``."""
+    help_text = _run_help(binary)
+    subcommands: Set[str] = set()
+    pattern = re.compile(r"^\s{2,}([\w-]+)(\s{2,}|$)")
+    for block in _iter_command_blocks(help_text):
+        for line in block:
+            match = pattern.match(line)
+            if match:
+                subcommands.add(match.group(1))
+        if subcommands:
+            break
+    return subcommands
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Compute the Levenshtein distance between two strings."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i]
+        for j, cb in enumerate(b, 1):
+            cost = 0 if ca == cb else 1
+            cur.append(
+                min(
+                    prev[j] + 1,
+                    cur[j - 1] + 1,
+                    prev[j - 1] + cost,
+                )
+            )
+        prev = cur
+    return prev[-1]
+
+
+def ensure_subcommand(binary: str, subcmd: str) -> None:
+    """Ensure that ``subcmd`` exists for ``binary`` or raise ``ValueError``."""
+    subcommands = list_subcommands(binary)
+    if subcmd in subcommands:
+        return
+    suggestions = sorted([c for c in subcommands if _levenshtein(subcmd, c) <= 2])
+    msg = (
+        f"Commande inconnue: {subcmd}\n"
+        "Sous-commandes disponibles pour {binary}: "
+        f"{', '.join(sorted(subcommands))}"
+    )
+    if suggestions:
+        msg += f"\nAstuce: avez-vous voulu dire '{suggestions[0]}' ?"
+    raise ValueError(msg)
+
+
+def run_cli(
+    binary: str, args: Sequence[str] | None = None, *, dry_run: bool = False
+) -> CompletedProcess[str]:
+    """Run ``binary`` with ``args`` after validating the subcommand.
+
+    Parameters
+    ----------
+    binary: str
+        The executable to run.
+    args: Sequence[str]
+        Command arguments; the first element is treated as subcommand.
+    dry_run: bool
+        If True, the command is only logged and not executed.
+    """
+    if args is None:
+        args = []
+    args = list(args)
+    if args:
+        subcmd = args[0]
+        subcmd = ALIASES.get(binary, {}).get(subcmd, subcmd)
+        ensure_subcommand(binary, subcmd)
+        args[0] = subcmd
+    cmd = [binary] + args
+    logger.info("Executing: %s", " ".join(cmd))
+    if dry_run:
+        print(" ".join(cmd))
+        return CompletedProcess(cmd, 0, "", "")
+    try:
+        cp = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = (
+            f"Command {' '.join(cmd)} failed with code {exc.returncode}\n"
+            f"stdout: {exc.stdout}\n"
+            f"stderr: {exc.stderr}"
+        )
+        raise RuntimeError(msg) from exc
+    return cp
+
+
+def get_secret(service: str, user: str) -> str:
+    """Retrieve a secret from keyring or environment variables.
+
+    Environment variable fallback is ``{SERVICE}_{USER}_TOKEN`` with both parts
+    upper‑cased.
+    """
+    secret = None
+    try:
+        import keyring  # type: ignore
+
+        secret = keyring.get_password(service, user)
+    except Exception:  # pragma: no cover - keyring may be missing
+        secret = None
+    if secret:
+        return secret
+    env_key = f"{service}_{user}_TOKEN".upper().replace("-", "_")
+    secret = os.environ.get(env_key)
+    if secret:
+        return secret
+    raise RuntimeError(
+        "Aucun secret trouvé pour le service '{service}' et l'utilisateur '{user}'. "
+        f"Installez 'keyring' ou définissez la variable d'environnement {env_key}."
+    )

--- a/ledgerize/src/app/main.py
+++ b/ledgerize/src/app/main.py
@@ -1,0 +1,17 @@
+"""Simple wrapper to execute binaries through :func:`run_cli`."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from .cli_safe import run_cli
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run a CLI with validation")
+    parser.add_argument("--dry-run", action="store_true", help="Only validate")
+    parser.add_argument("binary", help="Executable to run")
+    parser.add_argument("args", nargs=argparse.REMAINDER, help="Arguments")
+    ns = parser.parse_args(argv)
+    run_cli(ns.binary, ns.args, dry_run=ns.dry_run)

--- a/ledgerize/src/app/tools.py
+++ b/ledgerize/src/app/tools.py
@@ -1,0 +1,19 @@
+"""Miscellaneous helper tools for the application."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from .cli_safe import list_subcommands
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    ps = sub.add_parser("print-subcommands", help="List subcommands of a binary")
+    ps.add_argument("binary")
+    ns = parser.parse_args(argv)
+    if ns.cmd == "print-subcommands":
+        for name in sorted(list_subcommands(ns.binary)):
+            print(name)

--- a/ledgerize/src/ledgerize/vault.py
+++ b/ledgerize/src/ledgerize/vault.py
@@ -59,8 +59,14 @@ def lock(data_dir: Path, vault_file: Path, key: Optional[bytes] = None) -> None:
     manifest = Manifest(
         version="1",
         created=datetime.utcnow().isoformat(),
-        files=[{"path": str(p.relative_to(data_dir)), "size": p.stat().st_size}
-               for p in data_dir.rglob("*") if p.is_file()],
+        files=[
+            {
+                "path": str(p.relative_to(data_dir)),
+                "size": str(p.stat().st_size),
+            }
+            for p in data_dir.rglob("*")
+            if p.is_file()
+        ],
         nonce=base64.b64encode(nonce).decode(),
     )
     aad = MAGIC + manifest.to_json()
@@ -80,12 +86,12 @@ def unlock(vault_file: Path, out_dir: Path, key: Optional[bytes] = None) -> None
     if not data.startswith(MAGIC):
         raise ValueError("invalid vault file")
     idx = len(MAGIC)
-    mlen = int.from_bytes(data[idx:idx + 4], "big")
+    mlen = int.from_bytes(data[idx : idx + 4], "big")
     idx += 4
-    mbytes = data[idx:idx + mlen]
+    mbytes = data[idx : idx + mlen]
     idx += mlen
-    manifest = json.loads(mbytes)
-    nonce = data[idx:idx + 12]
+    _manifest = json.loads(mbytes)
+    nonce = data[idx : idx + 12]
     idx += 12
     ct = data[idx:]
     aesgcm = AESGCM(key)

--- a/ledgerize/tests/test_cli_safe.py
+++ b/ledgerize/tests/test_cli_safe.py
@@ -1,0 +1,78 @@
+import subprocess
+import shutil
+
+import pytest
+
+from app.cli_safe import list_subcommands, ensure_subcommand, run_cli
+
+CLICK_HELP = """Usage: prog [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  import   Import data
+  report   Generate report
+  preview  Preview data
+"""
+
+TYPER_HELP = """Usage: prog [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --install-completion  Install completion
+  --help                Show this message and exit.
+
+Commands:
+  import   Import data
+  report   Generate report
+  preview  Preview data
+"""
+
+ARGPARSE_HELP = """usage: prog [-h] {import,report,preview} ...
+
+positional arguments:
+  {import,report,preview}
+    import   Import data
+    report   Generate report
+    preview  Preview data
+"""
+
+
+@pytest.mark.parametrize("output", [CLICK_HELP, TYPER_HELP, ARGPARSE_HELP])
+def test_list_subcommands_parsing(monkeypatch, output):
+    def fake_run(cmd, capture_output, text, timeout, check):
+        return subprocess.CompletedProcess(cmd, 0, output, "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert list_subcommands("prog") == {"import", "report", "preview"}
+
+
+def test_ensure_subcommand_suggestion(monkeypatch):
+    monkeypatch.setattr(
+        "app.cli_safe.list_subcommands", lambda binary: {"import", "report", "preview"}
+    )
+    with pytest.raises(ValueError) as exc:
+        ensure_subcommand("prog", "improt")
+    assert "import" in str(exc.value)
+
+
+def test_run_cli_exec(monkeypatch):
+    monkeypatch.setattr("app.cli_safe.list_subcommands", lambda binary: {"import"})
+
+    calls = {}
+
+    def fake_run(cmd, text, capture_output, check, timeout):
+        calls["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    cp = run_cli("prog", ["import"])
+    assert cp.stdout == "ok"
+    assert calls["cmd"] == ["prog", "import"]
+
+
+@pytest.mark.xfail(shutil.which("ledgerize") is None, reason="ledgerize missing")
+def test_integration_ledgerize():
+    cmds = list_subcommands("ledgerize")
+    assert cmds
+    ensure_subcommand("ledgerize", "import")

--- a/ledgerize/tests/test_guard.py
+++ b/ledgerize/tests/test_guard.py
@@ -6,9 +6,9 @@ from ledgerize.guard import ensure_clean_repo
 
 def test_guard_detects(tmp_path: Path) -> None:
     repo = tmp_path
-    (repo / '.git').mkdir()
-    data = repo / 'data'
+    (repo / ".git").mkdir()
+    data = repo / "data"
     data.mkdir()
-    (data / 'x.csv').write_text('a')
+    (data / "x.csv").write_text("a")
     with pytest.raises(click.ClickException):
         ensure_clean_repo(repo)

--- a/ledgerize/tests/test_secure_flow.py
+++ b/ledgerize/tests/test_secure_flow.py
@@ -11,25 +11,25 @@ def test_secure_import(tmp_path: Path, monkeypatch) -> None:
     key = os.urandom(32)
     monkeypatch.setattr(vault, "_load_key", lambda: key)
     runner = CliRunner()
-    out_dir = tmp_path / 'data'
-    vault_dir = tmp_path / 'vault'
+    out_dir = tmp_path / "data"
+    vault_dir = tmp_path / "vault"
     result = runner.invoke(
         main,
         [
-            'import',
-            str(BASE / 'samples'),
-            '--rules',
-            str(BASE / 'samples/rules.yml'),
-            '--accounts',
-            str(BASE / 'samples/accounts.yml'),
-            '--out',
+            "import",
+            str(BASE / "samples"),
+            "--rules",
+            str(BASE / "samples/rules.yml"),
+            "--accounts",
+            str(BASE / "samples/accounts.yml"),
+            "--out",
             str(out_dir),
-            '--secure',
-            '--vault-dir',
+            "--secure",
+            "--vault-dir",
             str(vault_dir),
         ],
     )
     assert result.exit_code == 0
-    vault_file = vault_dir / 'data.lzvault'
+    vault_file = vault_dir / "data.lzvault"
     assert vault_file.exists()
-    assert not (out_dir / 'ledgerize.db').exists()
+    assert not (out_dir / "ledgerize.db").exists()


### PR DESCRIPTION
## Summary
- add `cli_safe` helper to validate and run CLI commands safely
- expose `python -m app` with dry-run and subcommand listing tools
- document safe CLI execution and troubleshooting steps

## Testing
- `poetry run ruff src tests`
- `poetry run black --check src tests`
- `poetry run mypy src`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a19a7b01c08324b4d69a4d7d1a5710